### PR TITLE
Install python 2.7, supervisor and (almost) arteria-bcl2fastq

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -116,19 +116,11 @@ Vagrant.configure(2) do |config|
     testtank.vm.synced_folder "../arteria-provisioning/", "/arteria/arteria-provisioning"
     #testtank.vm.synced_folder "/data/arteria_test_data/", "/data/testarteria1/mon1/"
 
-    config.vm.provision "file",
-        source: "arteria-docker/dependencies/build_data/supervisord.conf",
-        destination: "/tmp/supervisord.conf"
+    testtank.vm.provision "ansible" do |ansible|
+      ansible.playbook = "ansible-st2/playbooks/arteriaexpress.yaml"
+      ansible.inventory_path = "ansible-st2/inventories/test_inventory"
+    end
 
-    config.vm.provision "shell", inline: "cp /tmp/supervisord.conf /etc/supervisord.conf", privileged: true
-
-    config.vm.provision "file",
-        source: "arteria-docker/dependencies/build_data/supervisord_init",
-        destination: "/tmp/supervisord_init"
-
-    config.vm.provision "shell", inline: "cp /tmp/supervisord_init /etc/init.d/supervisord", privileged: true
-
-    testtank.vm.provision "shell", inline: $script, privileged: true
   end
 
   # Deploy ssh keys to all host to ensure they have the

--- a/ansible-st2/inventories/test_inventory
+++ b/ansible-st2/inventories/test_inventory
@@ -1,3 +1,6 @@
 [master]
 stackstorm-master
 
+[nodes]
+testarteria1
+

--- a/ansible-st2/playbooks/arteriaexpress.yaml
+++ b/ansible-st2/playbooks/arteriaexpress.yaml
@@ -22,3 +22,10 @@
     - mistral
     - st2web
     - arteria 
+
+- name: Setup the testarteria1 node
+  remote_user: vagrant
+  sudo: true
+  hosts: nodes
+  roles:
+    - arteria_node

--- a/ansible-st2/roles/arteria_node/handlers/main.yml
+++ b/ansible-st2/roles/arteria_node/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: start supervisord
+  service:
+    name: supervisord
+    state: started

--- a/ansible-st2/roles/arteria_node/tasks/arteria_bcl2fastq.yml
+++ b/ansible-st2/roles/arteria_node/tasks/arteria_bcl2fastq.yml
@@ -1,0 +1,18 @@
+---
+
+#TODO Ensure all this is versioned!
+
+- name: install illumina bcl2fastq
+  yum:
+    name: http://support.illumina.com/content/dam/illumina-support/documents/downloads/software/bcl2fastq/bcl2fastq2-v2.17.1.14-Linux-x86_64.rpm
+    state: present
+
+- name: install arteria-bcl2fastq requirements
+  pip:
+    requirements: https://raw.githubusercontent.com/arteria-project/arteria-bcl2fastq/master/requirements.txt
+    executable: /usr/local/bin/pip
+
+- name: install arteria-bcl2fastq
+  pip:
+    name: git+https://github.com/johandahlberg/arteria-bcl2fastq.git#egg=Package
+    executable: /usr/local/bin/pip

--- a/ansible-st2/roles/arteria_node/tasks/core_tasks.yml
+++ b/ansible-st2/roles/arteria_node/tasks/core_tasks.yml
@@ -1,0 +1,91 @@
+---
+
+- name: install the 'Development tools' package group
+  yum: name="@Development tools" state=present
+
+- name: Install python-compile pre-reqs
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - zlib-devel
+    - openssl-devel
+    - sqlite-devel
+    - bzip2-devel
+    - wget
+    - tar
+
+- name: Get python sources
+  get_url:
+    url: https://www.python.org/ftp/python/2.7.10/Python-2.7.10.tgz
+    dest: /usr/src/
+    sha256sum: eda8ce6eec03e74991abb5384170e7c65fcd7522e409b8e83d7e6372add0f12a
+
+- name: Untar python sources
+  unarchive: src=/usr/src/Python-2.7.10.tgz dest=/usr/src copy=no
+
+- name: compile python
+  shell: ./configure && make --quiet altinstall && touch ansible_state_completed
+  args:
+    chdir: /usr/src/Python-2.7.10
+    creates: /usr/src/Python-2.7.10/ansible_state_completed
+
+
+- name: download python setup-tools
+  get_url:
+    url: https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz
+    dest: /usr/src/
+    sha256sum: 263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd
+
+- name: Untar setup-tools
+  unarchive:
+    src: /usr/src/setuptools-1.4.2.tar.gz
+    dest: /usr/src
+    copy: no
+
+- name: install setup-tools
+  shell: /usr/local/bin/python2.7 setup.py install && touch setuptools-1.4.2
+  args:
+    chdir: /usr/src/setuptools-1.4.2
+    creates: /usr/src/setuptools-1.4.2/ansible_state_completed
+
+- name: install pip
+  shell: curl -q https://raw.githubusercontent.com/pypa/pip/master/contrib/get-pip.py | /usr/local/bin/python2.7 -
+
+- name: install other packages
+  pip:
+    name: "{{ item }}"
+    executable: /usr/local/bin/pip
+  with_items:
+    - virtualenv
+    - supervisor
+
+- name: create supervisor directories
+  file:
+    path: /etc/supervisor/conf.d
+    state: directory
+
+- name: create supervisor directories
+  file:
+    path: /var/log/supervisor/
+    state: directory
+
+- name: deploy supervisord config
+  template:
+    src: supervisord.conf.j2
+    dest: /etc/supervisord.conf
+
+- name: deploy supervisord_init
+  template:
+    src: supervisord_init.j2
+    dest: /etc/init.d/supervisord
+    mode: u+x
+
+- name: chkconfig --add supervisord
+  shell: chkconfig --add supervisord
+
+- name: start supervisord
+  service:
+    name: supervisord
+    state: started
+

--- a/ansible-st2/roles/arteria_node/tasks/main.yml
+++ b/ansible-st2/roles/arteria_node/tasks/main.yml
@@ -1,3 +1,4 @@
 ---
 
-- include: core_tasks.yml
+#- include: core_tasks.yml
+- include: arteria_bcl2fastq.yml

--- a/ansible-st2/roles/arteria_node/tasks/main.yml
+++ b/ansible-st2/roles/arteria_node/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- include: core_tasks.yml

--- a/ansible-st2/roles/arteria_node/tasks/main.yml
+++ b/ansible-st2/roles/arteria_node/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
 
-#- include: core_tasks.yml
+- include: core_tasks.yml
 - include: arteria_bcl2fastq.yml

--- a/ansible-st2/roles/arteria_node/templates/supervisord.conf.j2
+++ b/ansible-st2/roles/arteria_node/templates/supervisord.conf.j2
@@ -1,0 +1,28 @@
+; supervisor config file
+
+[unix_http_server]
+file=/var/run/supervisor.sock   ; (the path to the socket file)
+chmod=0700                       ; sockef file mode (default 0700)
+
+[supervisord]
+logfile=/var/log/supervisor/supervisord.log ; (main log file;default $CWD/supervisord.log)
+pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
+childlogdir=/var/log/supervisor            ; ('AUTO' child log dir, default $TEMP)
+
+; the below section must remain in the config file for RPC
+; (supervisorctl/web interface) to work, additional interfaces may be
+; added by defining them in separate rpcinterface: sections
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL  for a unix socket
+
+; The [include] section can just contain the "files" setting.  This
+; setting can list multiple files (separated by whitespace or
+; newlines).  It can also contain wildcards.  The filenames are
+; interpreted as relative to this file.  Included files *cannot*
+; include files themselves.
+
+[include]
+files = /etc/supervisor/conf.d/*.conf

--- a/ansible-st2/roles/arteria_node/templates/supervisord_init.j2
+++ b/ansible-st2/roles/arteria_node/templates/supervisord_init.j2
@@ -1,0 +1,116 @@
+#!/bin/bash
+#
+# supervisord   Startup script for the Supervisor process control system
+#
+# Author:       Mike McGrath <mmcgrath@redhat.com> (based off yumupdatesd)
+#               Jason Koppe <jkoppe@indeed.com> adjusted to read sysconfig,
+#                   use supervisord tools to start/stop, conditionally wait
+#                   for child processes to shutdown, and startup later
+#               Erwan Queffelec <erwan.queffelec@gmail.com>
+#                   make script LSB-compliant
+#
+# chkconfig:    345 83 04
+# description: Supervisor is a client/server system that allows \
+#   its users to monitor and control a number of processes on \
+#   UNIX-like operating systems.
+# processname: supervisord
+# config: /etc/supervisord.conf
+# config: /etc/sysconfig/supervisord
+# pidfile: /var/run/supervisord.pid
+#
+### BEGIN INIT INFO
+# Provides: supervisord
+# Required-Start: $all
+# Required-Stop: $all
+# Short-Description: start and stop Supervisor process control system
+# Description: Supervisor is a client/server system that allows
+#   its users to monitor and control a number of processes on
+#   UNIX-like operating systems.
+### END INIT INFO
+
+# Source function library
+. /etc/rc.d/init.d/functions
+
+# Source system settings
+if [ -f /etc/sysconfig/supervisord ]; then
+    . /etc/sysconfig/supervisord
+fi
+
+# Path to the supervisorctl script, server binary,
+# and short-form for messages.
+supervisorctl=/usr/local/bin/supervisorctl
+supervisord=${SUPERVISORD-/usr/local/bin/supervisord}
+prog=supervisord
+pidfile=${PIDFILE-/var/run/supervisord.pid}
+lockfile=${LOCKFILE-/var/lock/subsys/supervisord}
+STOP_TIMEOUT=${STOP_TIMEOUT-60}
+OPTIONS="${OPTIONS--c /etc/supervisord.conf}"
+RETVAL=0
+
+start() {
+    echo -n $"Starting $prog: "
+    daemon --pidfile=${pidfile} $supervisord $OPTIONS
+    RETVAL=$?
+    echo
+    if [ $RETVAL -eq 0 ]; then
+        touch ${lockfile}
+        $supervisorctl $OPTIONS status
+    fi
+    return $RETVAL
+}
+
+stop() {
+    echo -n $"Stopping $prog: "
+    killproc -p ${pidfile} -d ${STOP_TIMEOUT} $supervisord
+    RETVAL=$?
+    echo
+    [ $RETVAL -eq 0 ] && rm -rf ${lockfile} ${pidfile}
+}
+
+reload() {
+    echo -n $"Reloading $prog: "
+    LSB=1 killproc -p $pidfile $supervisord -HUP
+    RETVAL=$?
+    echo
+    if [ $RETVAL -eq 7 ]; then
+        failure $"$prog reload"
+    else
+        $supervisorctl $OPTIONS status
+    fi
+}
+
+restart() {
+    stop
+    start
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    status)
+        status -p ${pidfile} $supervisord
+        RETVAL=$?
+        [ $RETVAL -eq 0 ] && $supervisorctl $OPTIONS status
+        ;;
+    restart)
+        restart
+        ;;
+    condrestart|try-restart)
+        if status -p ${pidfile} $supervisord >&/dev/null; then
+          stop
+          start
+        fi
+        ;;
+    force-reload|reload)
+        reload
+        ;;
+    *)
+        echo $"Usage: $prog {start|stop|restart|condrestart|try-restart|force-reload|reload}"
+        RETVAL=2
+esac
+
+exit $RETVAL


### PR DESCRIPTION
We can now install python 2.7 and supervisor to the test system, and I've started work on installing arteria-bcl2fastq.
