### PR TITLE
Expliclity give path to bcl2fastq

### DIFF
--- a/ansible-st2/roles/arteria_node/templates/bcl2fastq_app.config.j2
+++ b/ansible-st2/roles/arteria_node/templates/bcl2fastq_app.config.j2
@@ -4,7 +4,7 @@
 bcl2fastq:
   versions:
     2.17.1:
-      binary: bcl2fastq
+      binary: /usr/local/bin/bcl2fastq
       class_creation_function:  _get_bcl2fastq2x_runner
     2.15.2:
       binary: /path/to/bcl2fastq


### PR DESCRIPTION
This avoids making any assumptions about what is on the path.
