### PR TITLE
Deploy rsync include files

### DIFF
--- a/ansible-st2/roles/arteria_node/files/hiseq.rsync
+++ b/ansible-st2/roles/arteria_node/files/hiseq.rsync
@@ -1,0 +1,56 @@
+# Include all dirs. This is required for anything to work
+# Empty dirs can be excluded with --prune-empty-dirs
+#
+# cd <runfolder>
+# rsync -av --prune-empty-dirs --include-from hiseq.rsync $PWD/ biologin:~/incoming/runfolders/$runfolder > $PWD/rsync.log
+#
+
++ */
+
+# Include some files regardless of location in tree
++ sisyphus*
++ *.sbatch
++ *.yml
++ *.png
++ *.csv
++ *.htm
++ *.xml
++ *.xsl
++ *.sbatch.gz
++ *.yml.gz
++ *.png.gz
++ *.csv.gz
++ *.htm.gz
++ *.xml.gz
++ *.xsl.gz
++ *.qmat*
++ *.fastq*
++ Makefile*
++ nohup*
++ support.txt*
++ SampleSheet.*
++ Log.txt*
++ First_Base_Report.txt*
++ MiSeq_Runfolder.tar.gz
++ bcl2fastq.version
+
+# Exclude all .sentinel files
+- .sentinel
+
+# Include full tree of some subdirs
+# This works if rsync is called with src dest, but not src/ dest
++ /*/Sisyphus/***
++ /*/Unaligned/***
++ /*/Excluded/***
++ /*/Config/***
++ /*/Diag/***
++ /*/InterOp/***
++ /*/Logs/***
++ /*/Recipe/***
++ /*/Data/RTALogs/***
++ /*/Data/reports/***
++ /*/Data/Status_Files/***
++ /*/slurmlogs/***
++ /*/slurmscripts/***
+
+- *

--- a/ansible-st2/roles/arteria_node/files/ngi.rsync
+++ b/ansible-st2/roles/arteria_node/files/ngi.rsync
@@ -1,0 +1,22 @@
+# Include all dirs. This is required for anything to work
+# Empty dirs can be excluded with --prune-empty-dirs
+#
+# cd <runfolder>
+# rsync -avL --prune-empty-dirs --include-from hiseq.rsync $PWD/ biologin:~/incoming/runfolders/$runfolder > $PWD/rsync.log
+#
+
++ */
+
+# Include some files regardless of location in tree
++ SampleSheet.*
+
+# Exclude all .sentinel files
+- .sentinel
+
+# Include full tree of some subdirs
+# This works if rsync is called with src dest, but not src/ dest
++ /*/Demultiplexing/***
++ /*/InterOp/***
++ /*/Sisyphus/***
+
+- *

--- a/ansible-st2/roles/arteria_node/files/summary.rsync
+++ b/ansible-st2/roles/arteria_node/files/summary.rsync
@@ -1,0 +1,31 @@
+# Include/Exclude files and folders from the summaries saved
+
+- *.fastq*
+- .sentinel
+- /*/*_Netcopy_complete*
+- MiSeq_Runfolder.tar.gz
+
++ */
++ /*/*
+
++ /*/MD5/***
++ /*/InterOp/***
++ /*/Unaligned/Basecall_Stats_*/*
++ /*/Unaligned/Basecall_Stats_*/css/***
++ /*/Excluded/Basecall_Stats_*/*
++ /*/Excluded/Basecall_Stats_*/css/***
++ /*/Data/Status.htm*
++ /*/Data/Status_Files/***
++ /*/Data/reports/**.htm
++ /*/Data/reports/**.css
++ /*/Data/reports/**.xml
++ /*/Data/reports/**.xsl
+
+- /*/Logs/***
+- /*/Data/***
+- /*/Diag/***
+- /*/PeriodicSaveRates/***
+- /*/Sisyphus/***
+- /*/Thumbnail_Images/***
+
+- *

--- a/ansible-st2/roles/arteria_node/tasks/deploy_include_files.yml
+++ b/ansible-st2/roles/arteria_node/tasks/deploy_include_files.yml
@@ -1,0 +1,5 @@
+---
+
+- copy: src=hiseq.rsync dest=/etc/arteria/misc/
+- copy: src=ngi.rsync dest=/etc/arteria/misc/
+- copy: src=summary.rsync dest=/etc/arteria/misc/


### PR DESCRIPTION
We need to have access to rsync include files that will match which files should be rsynced and which should not be.
