### PR TITLE
Split out the st2 modifications 

### DIFF
--- a/ansible-st2/playbooks/arteriaexpress.yaml
+++ b/ansible-st2/playbooks/arteriaexpress.yaml
@@ -7,6 +7,7 @@
     # the StackStorm version to install
     version: 0.11.2
   roles:
+    - local_st2mods # Do some local modifications for St2 to work
     - st2op
     - mongodb
     - rabbitmq
@@ -20,10 +21,6 @@
         - st2debug
         - st2reactor
     - mysql
-    # Ugly hack for now. _arteria contains some dependencies for
-    # _mistral, but _arteria has to run last as well for some
-    # configs to be done.
-    - arteria
     - mistral
     - st2web
     - arteria

--- a/ansible-st2/roles/arteria/tasks/main.yml
+++ b/ansible-st2/roles/arteria/tasks/main.yml
@@ -1,8 +1,5 @@
 ---
 
-- name: Install libpq-dev
-  apt: name=libpq-dev state=present
-
 # TODO: Change this user name in a better way in the future..
 - name: Change the system user from the default stanley to our provision user
   sudo: yes
@@ -19,7 +16,7 @@
 
 - name: Get st2 token
   command: /bin/bash /arteria/arteria-packs/scripts/st2token
-  register: st2token 
+  register: st2token
 
 - name: Setup virtualenv for arteria-packs
   command: /bin/bash -c "ST2_AUTH_TOKEN={{ st2token.stdout }} /arteria/arteria-packs/scripts/setup-virtualenv"
@@ -31,7 +28,6 @@
   sudo: yes
   file: path=/var/log/arteria/ state=directory owner={{ ansible_ssh_user }} group={{ ansible_ssh_user }} mode=0755
 
-
 - name: Ensure api is reachable from web-ui
   sudo: yes
   ini_file:
@@ -42,5 +38,3 @@
     backup=yes
   notify:
     - restart st2
-
-  

--- a/ansible-st2/roles/local_st2mods/tasks/main.yml
+++ b/ansible-st2/roles/local_st2mods/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+  # This dependency is needed for Mistral to install correctly 
+- name: Install libpq-dev
+  apt: name=libpq-dev state=present


### PR DESCRIPTION
...from the arteria role to a new local st2mods role.

(Running the arteria role twice didn't work that well on a new fresh test system as things later in the role depended on other st2 services to be setup.)
