### PR TITLE
Rebuild the apt cache

### DIFF
--- a/ansible-st2/roles/local_st2mods/tasks/main.yml
+++ b/ansible-st2/roles/local_st2mods/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
-  # This dependency is needed for Mistral to install correctly 
+  # This dependency is needed for Mistral to install correctly
 - name: Install libpq-dev
   apt: name=libpq-dev state=present
+
+- name: rebuild apt cache due to transparent caches upstream 
+  shell: rm -rf /var/lib/apt/lists/* && apt-get update


### PR DESCRIPTION
Because sometimes there are weird behaviours caused by e.g. transparent proxies upstream, and similar (https://bugs.launchpad.net/ubuntu/+source/apt/+bug/972077)
