### PR TITLE
Moved sisphus to separate role

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -73,6 +73,19 @@ Vagrant.configure(2) do |config|
     testuppmax.vm.hostname = "testuppmax"
     testuppmax.vm.network :private_network, ip: '192.168.42.44'
 
+    testuppmax.vm.provision "shell", inline: "mkdir -p /tmp/runfolders"
+    testuppmax.vm.provision "shell", inline: "chown -R vagrant:vagrant /tmp/runfolders"
+    testuppmax.vm.provision "shell", inline: "mkdir -p /tmp/summaries"
+    testuppmax.vm.provision "shell", inline: "chown -R vagrant:vagrant /tmp/summaries"
+
+    testuppmax.vm.provision "shell", inline: 'echo export SNIC_RESOURCE=milou >> /home/vagrant/.bash_profile'
+    testuppmax.vm.provision "shell", inline: "printf '#!/bin/bash\necho $@\n' > /usr/local/bin/sbatch"
+    testuppmax.vm.provision "shell", inline: "chmod +x /usr/local/bin/sbatch"
+
+    testuppmax.vm.provision "ansible" do |ansible|
+      ansible.playbook = "ansible-st2/playbooks/arteriaexpress.yaml"
+      ansible.inventory_path = "ansible-st2/inventories/test_inventory"
+    end
   end
 
   # Deploy ssh keys to all host to ensure they have the

--- a/ansible-st2/inventories/test_inventory
+++ b/ansible-st2/inventories/test_inventory
@@ -4,3 +4,5 @@ stackstorm-master
 [nodes]
 testarteria1
 
+[remote]
+testuppmax

--- a/ansible-st2/playbooks/arteriaexpress.yaml
+++ b/ansible-st2/playbooks/arteriaexpress.yaml
@@ -30,4 +30,12 @@
   sudo: true
   hosts: nodes
   roles:
+    - sisyphus
     - arteria_node
+
+- name: Setup test remote node
+  remote_user: vagrant
+  sudo: true
+  hosts: remote
+  roles:
+    - sisyphus

--- a/ansible-st2/roles/arteria_node/tasks/arteria_siswrap.yml
+++ b/ansible-st2/roles/arteria_node/tasks/arteria_siswrap.yml
@@ -4,77 +4,8 @@
 # TODO: Investigate whether or not /usr/local/bin/ is in the path.
 #       I get it, but not JD.
 
-- name: install sisyphus dependencies from centos repository
-  yum:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - epel-release
-    - dos2unix
-    - gnuplot
-    - PyXML
-    - ImageMagick
-    - libxslt-devel
-    - libxml2-devel
-    - libxml2-devel
-    - ncurses-devel
-    - libtiff-devel
-    - perl-XML-LibXML
-    - perl-XML-LibXML-Common
-    - perl-XML-NamespaceSupport
-    - perl-XML-SAX
-    - perl-XML-Simple
-    - perl-Archive-Zip
-    - perl-CPAN
-    - git
 
-- name: install sisyphus dependencies from epel repository
-  yum:
-      name: "{{ item }}"
-      state: present
-      enablerepo: epel
-  with_items:
-    - perl-PDL
-    - perl-PerlIO-gzip
-
-- name: download cpanm
-  get_url: url=http://cpanmin.us dest=/tmp/cpanm_install.pl
-
-- name: install cpanm
-  command: perl /tmp/cpanm_install.pl --sudo App::cpanminus
-
-- name: install File::NFSLock
-  cpanm: name=File::NFSLock
-
-- name: create sisyphus code folder
-  file: path={{ sisyphus_path }} state=directory
-
-- name: get sisyphus code
-  git: repo={{ sisyphus_git_repo }} version={{ sisyphus_repo_branch }} dest={{ sisyphus_path }}/sisyphus-tmp update=yes
-
-- name: get sisyphus version
-  command: git --git-dir={{ sisyphus_path }}/sisyphus-tmp/.git describe --tags
-  register: sisyphus_version
-
-- name: check if latest sisyphus version folder exists
-  stat: path={{ sisyphus_path }}/sisyphus-{{ sisyphus_version.stdout }}
-  register: latest_sisyphus_version_folder
-
-- name: copy latest version to correct named folder
-  command: cp -r {{ sisyphus_path }}/sisyphus-tmp {{ sisyphus_path }}/sisyphus-{{ sisyphus_version.stdout }}
-  when: not latest_sisyphus_version_folder.stat.exists
-
-- name: remove sisyphus-tmp
-  file: path={{ sisyphus_path }}/sisyphus-tmp state=absent
-
-- name: ensure latest version is globally readable
-  file: state=directory path={{ sisyphus_path }}/sisyphus-{{ sisyphus_version.stdout }} mode=775 recurse=yes
-
-- name: setup link to sisyphus latest
-  file: state=link src={{ sisyphus_path }}/sisyphus-{{ sisyphus_version.stdout }} dest={{ sisyphus_path }}/sisyphus-latest mode=775
-
-- name: set acl permissions on sisyphus code folder
-  command: setfacl -R -m u:{{ arteria_user }}:rwx {{ sisyphus_path }}
+# This all assumes that the sisyphus role has been run before this.
 
 # qcValidateRun.pl looks for sisyphus_qc.xml in the runfolder, if not
 # manually specified on the command line. QCWrapper will at the moment

--- a/ansible-st2/roles/sisyphus/defaults/main.yml
+++ b/ansible-st2/roles/sisyphus/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+
+
+arteria_user: vagrant
+install_path: /opt/arteria/
+
+arteria_siswrap_path: "{{ install_path }}/arteria-siswrap-env"
+sisyphus_path: "{{ arteria_siswrap_path }}/deps/sisyphus/"
+sisyphus_git_repo: https://github.com/Molmed/sisyphus.git
+sisyphus_repo_branch: master

--- a/ansible-st2/roles/sisyphus/tasks/main.yml
+++ b/ansible-st2/roles/sisyphus/tasks/main.yml
@@ -1,0 +1,73 @@
+---
+
+- name: install sisyphus dependencies from centos repository
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - epel-release
+    - dos2unix
+    - gnuplot
+    - PyXML
+    - ImageMagick
+    - libxslt-devel
+    - libxml2-devel
+    - libxml2-devel
+    - ncurses-devel
+    - libtiff-devel
+    - perl-XML-LibXML
+    - perl-XML-LibXML-Common
+    - perl-XML-NamespaceSupport
+    - perl-XML-SAX
+    - perl-XML-Simple
+    - perl-Archive-Zip
+    - perl-CPAN
+    - git
+
+- name: install sisyphus dependencies from epel repository
+  yum:
+      name: "{{ item }}"
+      state: present
+      enablerepo: epel
+  with_items:
+    - perl-PDL
+    - perl-PerlIO-gzip
+
+- name: download cpanm
+  get_url: url=http://cpanmin.us dest=/tmp/cpanm_install.pl
+
+- name: install cpanm
+  command: perl /tmp/cpanm_install.pl --sudo App::cpanminus
+
+- name: install File::NFSLock
+  cpanm: name=File::NFSLock
+
+- name: create sisyphus code folder
+  file: path={{ sisyphus_path }} state=directory
+
+- name: get sisyphus code
+  git: repo={{ sisyphus_git_repo }} version={{ sisyphus_repo_branch }} dest={{ sisyphus_path }}/sisyphus-tmp update=yes
+
+- name: get sisyphus version
+  command: git --git-dir={{ sisyphus_path }}/sisyphus-tmp/.git describe --tags
+  register: sisyphus_version
+
+- name: check if latest sisyphus version folder exists
+  stat: path={{ sisyphus_path }}/sisyphus-{{ sisyphus_version.stdout }}
+  register: latest_sisyphus_version_folder
+
+- name: copy latest version to correct named folder
+  command: cp -r {{ sisyphus_path }}/sisyphus-tmp {{ sisyphus_path }}/sisyphus-{{ sisyphus_version.stdout }}
+  when: not latest_sisyphus_version_folder.stat.exists
+
+- name: remove sisyphus-tmp
+  file: path={{ sisyphus_path }}/sisyphus-tmp state=absent
+
+- name: ensure latest version is globally readable
+  file: state=directory path={{ sisyphus_path }}/sisyphus-{{ sisyphus_version.stdout }} mode=775 recurse=yes
+
+- name: setup link to sisyphus latest
+  file: state=link src={{ sisyphus_path }}/sisyphus-{{ sisyphus_version.stdout }} dest={{ sisyphus_path }}/sisyphus-latest mode=775
+
+- name: set acl permissions on sisyphus code folder
+  command: setfacl -R -m u:{{ arteria_user }}:rwx {{ sisyphus_path }}


### PR DESCRIPTION
I've moved sisyphus to a separate role so that it can be installed to testuppmax. I also made a ugly trick - adding a small script called sbatch the path which only echos anything passed to it to "fake" a slurm
environment. This is probably something that we want to do better in the future.
