### PR TITLE
No SMTP rewrite is needed for the trial system that we supply..

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ You'll need the following repos (if you are using the Vagrant file):
     ./arteria-bcl2fastq
     ./arteria-siswrap
 
+*Configuring mail sending*
+
+There is a sample configuration for Postfix bundled, that relays mail via Gmail. This needs to be manually adopted and changed by the user for her specific needs, if she wants Stackstorm to be able to send notification emails when an error in the workflow has occurred.
+
+Edit `/etc/postfix/sasl/sasl_passwd`. After saving run `postmap /etc/postfix/sasl/sasl_passwd`. Verify that the email configuration works with e.g. `echo arteriatest | mail -s arteriatest user@host`, where `user@host` is the recipient address you want to try mailing. If it doesn't seem to work then an inspection of the log file `/var/log/mail.log` together with the Postfix manual is recommended. 
+
 *The arteria system*
 
 The vagrant setup and ansible playbook here demonstrates a simple usage scenario where we have one central StackStorm

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ You'll need the following repos (if you are using the Vagrant file):
 
 There is a sample configuration for Postfix bundled, that relays mail via Gmail. This needs to be manually adopted and changed by the user for her specific needs, if she wants Stackstorm to be able to send notification emails when an error in the workflow has occurred.
 
-Edit `/etc/postfix/sasl/sasl_passwd`. After saving run `postmap /etc/postfix/sasl/sasl_passwd`. Verify that the email configuration works with e.g. `echo arteriatest | mail -s arteriatest user@host`, where `user@host` is the recipient address you want to try mailing. If it doesn't seem to work then an inspection of the log file `/var/log/mail.log` together with the Postfix manual is recommended. 
+Edit `/etc/postfix/sasl/sasl_passwd`. After saving run `postmap /etc/postfix/sasl/sasl_passwd`. Login to your Google account and go to https://myaccount.google.com. Navigate to /Sign-in & security -> Connected apps & sites/, and enable there the option /Allow less secure apps/.  
+
+Now verify that the email configuration works with e.g. `echo arteriatest | mail -s arteriatest user@host`, where `user@host` is the recipient address you want to try mailing. If it doesn't seem to work then an inspection of the log file `/var/log/mail.log` together with the Postfix manual is recommended. 
 
 *The arteria system*
 

--- a/ansible-st2-local/roles/arteria/handlers/main.yml
+++ b/ansible-st2-local/roles/arteria/handlers/main.yml
@@ -1,2 +1,3 @@
 - name: restart postfix
+  sudo: true
   service: name=postfix state=restarted enabled=yes

--- a/ansible-st2-local/roles/arteria/tasks/arteria_mailclient.yml
+++ b/ansible-st2-local/roles/arteria/tasks/arteria_mailclient.yml
@@ -22,11 +22,6 @@
     - ca-certificates
     - libsasl2-modules
 
-- name: get ansible's local hostname, used for address rewriting on  test deployment
-  local_action: command hostname -A
-  register: smtp_local_orchestring_hostname
-  sudo: false
-
 - name: distribute gmail authentication file
   sudo: true
   copy: src=sasl_passwd dest=/etc/postfix/sasl/sasl_passwd backup=yes owner=postfix mode=0440
@@ -34,10 +29,6 @@
 - name: distribute postfix configuration
   sudo: true
   template: src=etc_postfix_main.cf.j2 dest=/etc/postfix/main.cf backup=yes
-
-- name: distribute smtp_rewrite configuration and restart service
-  sudo: true
-  template: src=etc_postfix_smtp_rewrite.j2 dest=/etc/postfix/smtp_rewrite backup=yes
 
 - name: copy certificate to right place
   sudo: true
@@ -50,3 +41,4 @@
 - name: rebuild the hash
   sudo: true
   shell: postmap /etc/postfix/sasl/sasl_passwd
+  notify: restart postfix

--- a/ansible-st2-local/roles/arteria/templates/etc_postfix_smtp_rewrite.j2
+++ b/ansible-st2-local/roles/arteria/templates/etc_postfix_smtp_rewrite.j2
@@ -1,4 +1,0 @@
-# Rewrite for test systems. If you have proper DNS you might not need this
-{% if smtp_rewrite %}
-/(.*)@{{ ansible_fqdn }}/ $1.{{ ansible_hostname }}@{{ smtp_local_orchestring_hostname.stdout }}
-{% endif %}


### PR DESCRIPTION
... as the user is supposed to play with the Gmail integration instead.

Note that for our own internal SNP&SEQ test usages we need to apply the `mail_client` role in the system-administration repo.
