### PR TITLE
Change vagrant user to arteria

### DIFF
--- a/ansible-st2-local/roles/sisyphus/defaults/main.yml
+++ b/ansible-st2-local/roles/sisyphus/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 
-arteria_user: vagrant 
+arteria_user: arteria
 install_path: /opt/arteria/
 
 arteria_siswrap_path: "{{ install_path }}/arteria-siswrap-env"

--- a/ansible-st2-local/roles/sisyphus/defaults/main.yml
+++ b/ansible-st2-local/roles/sisyphus/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 
-arteria_user: arteria
+arteria_sisyphus_user: vagrant
 install_path: /opt/arteria/
 
 arteria_siswrap_path: "{{ install_path }}/arteria-siswrap-env"

--- a/ansible-st2-local/roles/sisyphus/tasks/main.yml
+++ b/ansible-st2-local/roles/sisyphus/tasks/main.yml
@@ -70,4 +70,4 @@
   file: state=link src={{ sisyphus_path }}/sisyphus-{{ sisyphus_version.stdout }} dest={{ sisyphus_path }}/sisyphus-latest mode=775
 
 - name: set acl permissions on sisyphus code folder
-  command: setfacl -R -m u:{{ arteria_user }}:rwx {{ sisyphus_path }}
+  command: setfacl -R -m u:{{ arteria_sisyphus_user }}:rwx {{ sisyphus_path }}


### PR DESCRIPTION
- Sisyphus role is still using vagrant as arteria_user. Change to arteria.
- This has the effect of all services failing, since the owner of the log dir becomes vagrant
