### PR TITLE
Tell Ansible which user and key to use, for easier manual runs

### DIFF
--- a/ansible-st2-local/inventories/test_inventory
+++ b/ansible-st2-local/inventories/test_inventory
@@ -7,7 +7,7 @@ remote
 # specify the key explictely. Assumes ansible-playbook 
 # is run from the arteria-provisioning dir.   
 [arteria:vars]
-#ansible_ssh_private_key_file=./private_key
+ansible_ssh_private_key_file=./private_key
 
 [master]
 stackstorm-master

--- a/ansible-st2-local/inventories/test_inventory
+++ b/ansible-st2-local/inventories/test_inventory
@@ -1,3 +1,14 @@
+[arteria:children]
+master
+nodes
+remote
+
+# Needed for manual Ansible runs if we do not want to 
+# specify the key explictely. Assumes ansible-playbook 
+# is run from the arteria-provisioning dir.   
+[arteria:vars]
+#ansible_ssh_private_key_file=./private_key
+
 [master]
 stackstorm-master
 

--- a/ansible-st2-local/playbooks/arteriaexpress.yaml
+++ b/ansible-st2-local/playbooks/arteriaexpress.yaml
@@ -1,5 +1,6 @@
 ---
 - name: Install st2 for arteria
+  remote_user: vagrant
   hosts: master
   vars:
     st2_version: 0.13.2


### PR DESCRIPTION
If a user e.g. wants to re-provision some specific tags, then being able to run `ansible-playbook` manually instead of via `vagrant provision` is probably good. 
