### PR TITLE
systems user in sudoers optional

### DIFF
--- a/ansible-st2-local/playbooks/arteriaexpress.yaml
+++ b/ansible-st2-local/playbooks/arteriaexpress.yaml
@@ -5,6 +5,7 @@
   vars:
     st2_version: 0.13.2
     st2web_version: 0.13.2
+    st2_system_user_in_sudoers: no
   roles:
     # Postgres requires that the en_US.UTF-8 locale is set - this fixes that
     - locale

--- a/ansible-st2/roles/st2/tasks/3.user.yml
+++ b/ansible-st2/roles/st2/tasks/3.user.yml
@@ -29,6 +29,6 @@
     mode: 0440
     regexp: "^{{ st2_system_user }} ALL="
     line: "{{ st2_system_user }} ALL=(ALL) NOPASSWD: SETENV: ALL"
-    state: present
+    state: "{{ st2_system_user_in_sudoers | ternary('present','absent') }}"
     validate: 'visudo -cf %s'
   tags: [st2, user]


### PR DESCRIPTION
It's now optional to add the system users to sudoers. Maybe we should try to get this merged upstream - what do you think?
