### PR TITLE
Do not disable iptables

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -60,6 +60,12 @@ Vagrant.configure(2) do |config|
     testtank.vm.synced_folder "../arteria-provisioning/", "/arteria/arteria-provisioning"
     #testtank.vm.synced_folder "/data/arteria_test_data/", "/data/testarteria1/runfolders"
 
+    # By default this box has iptables enabled on all ports
+    # since the Ansible provisioning does not handle firewall configuration
+    # at the moment we need to ensure that all services can be accessed
+    # anyway. We do this by dropping the reject all rule here:
+    config.vm.provision "shell", inline: "sudo iptables -D INPUT 5; echo 0;"
+
     testtank.vm.provision "ansible" do |ansible|
       ansible.playbook = "ansible-st2/playbooks/arteriaexpress.yaml"
       ansible.inventory_path = "ansible-st2/inventories/test_inventory"

--- a/ansible-st2-local/playbooks/arteriaexpress.yaml
+++ b/ansible-st2-local/playbooks/arteriaexpress.yaml
@@ -5,6 +5,7 @@
   vars:
     st2_version: 0.13.2
     st2web_version: 0.13.2
+    st2_system_user_in_sudoers: no
   roles:
     # Postgres requires that the en_US.UTF-8 locale is set - this fixes that
     - locale

--- a/ansible-st2-local/roles/arteria_core/defaults/main.yml
+++ b/ansible-st2-local/roles/arteria_core/defaults/main.yml
@@ -1,7 +1,5 @@
 ---
 
-arteria_disable_iptables: true
-
 arteria_user: arteria
 arteria_uid: 4242
 arteria_group: arteria

--- a/ansible-st2-local/roles/arteria_core/tasks/main.yml
+++ b/ansible-st2-local/roles/arteria_core/tasks/main.yml
@@ -104,7 +104,3 @@
   file:
     state: directory
     path: /etc/arteria
-
-- name: disable iptables
-  service: name=iptables state=stopped enabled=no
-  when: arteria_disable_iptables

--- a/ansible-st2/roles/st2/tasks/3.user.yml
+++ b/ansible-st2/roles/st2/tasks/3.user.yml
@@ -29,6 +29,6 @@
     mode: 0440
     regexp: "^{{ st2_system_user }} ALL="
     line: "{{ st2_system_user }} ALL=(ALL) NOPASSWD: SETENV: ALL"
-    state: present
+    state: "{{ st2_system_user_in_sudoers | ternary('present','absent') }}"
     validate: 'visudo -cf %s'
   tags: [st2, user]


### PR DESCRIPTION
I managed to get this a bit mangled up now with commits from #56. But once that is merged I can rebase this and we'll be alright.

Do you guys thing that the `sudo iptables -D INPUT 5; echo 0;` is to much of a hack? The `echo 0` needed because otherwise the provisioning fails if if it's rerun since the rule does not exist.
