### PR TITLE
Don't register arteria-packs on production systems..

### DIFF
--- a/ansible-st2-local/playbooks/arteriaexpress.yaml
+++ b/ansible-st2-local/playbooks/arteriaexpress.yaml
@@ -13,6 +13,7 @@
     mistral_db_password: ArteriaKicksAzz
     postgresql_logging_collector: on
     postgresql_log_directory: /var/log/postgresql
+    arteria_environment: staging
   roles:
     # Postgres requires that the en_US.UTF-8 locale is set - this fixes that
     - locale

--- a/ansible-st2-local/roles/arteria/tasks/main.yml
+++ b/ansible-st2-local/roles/arteria/tasks/main.yml
@@ -9,8 +9,12 @@
 - name: Pause for 1 minute until stackstorm services are up and online
   pause: minutes=1
 
+# FIXME: These steps has to be done manually for non-test systems at the moment, 
+# because we do not want passwords on live systems in clear text. Have to find
+# a better method later. 
 - include: register_components.yml
   tags: arteria_register_components
+  when: arteria_environment == "staging" 
 
 - name: Override paramiko setting (currently buggy)
   sudo: yes


### PR DESCRIPTION
..due to passwords in clear text.
