### PR TITLE
File permissions on Arteria nodes

### DIFF
--- a/ansible-st2-local/roles/arteria_core/tasks/main.yml
+++ b/ansible-st2-local/roles/arteria_core/tasks/main.yml
@@ -25,7 +25,7 @@
   unarchive: src=/usr/src/Python-2.7.10.tgz dest=/usr/src copy=no
 
 - name: compile python
-  shell: ./configure && make --quiet altinstall && touch ansible_state_completed
+  shell: umask 0022 && ./configure && make --quiet altinstall && touch ansible_state_completed
   args:
     chdir: /usr/src/Python-2.7.10
     creates: /usr/src/Python-2.7.10/ansible_state_completed
@@ -43,7 +43,7 @@
     copy: no
 
 - name: install setup-tools
-  shell: /usr/local/bin/python2.7 setup.py install && touch /usr/src/setuptools-1.4.2/ansible_state_completed
+  shell: umask 0022 && /usr/local/bin/python2.7 setup.py install && touch /usr/src/setuptools-1.4.2/ansible_state_completed
   args:
     chdir: /usr/src/setuptools-1.4.2
     creates: /usr/src/setuptools-1.4.2/ansible_state_completed

--- a/ansible-st2-local/roles/arteria_core/tasks/main.yml
+++ b/ansible-st2-local/roles/arteria_core/tasks/main.yml
@@ -99,3 +99,10 @@
     state: directory
     path: /etc/arteria
     owner: "{{ arteria_user }}"
+
+- name: ensure /opt/arteria dir exists with proper owner
+  file: 
+    state: directory
+    path: /opt/arteria
+    owner: "{{ arteria_user }}"
+

--- a/ansible-st2-local/roles/arteria_core/tasks/main.yml
+++ b/ansible-st2-local/roles/arteria_core/tasks/main.yml
@@ -98,3 +98,4 @@
   file:
     state: directory
     path: /etc/arteria
+    owner: "{{ arteria_user }}"

--- a/ansible-st2-local/roles/arteria_node/tasks/deploy_include_files.yml
+++ b/ansible-st2-local/roles/arteria_node/tasks/deploy_include_files.yml
@@ -1,5 +1,5 @@
 ---
 
-- copy: src=hiseq.rsync dest=/etc/arteria/misc/
-- copy: src=ngi.rsync dest=/etc/arteria/misc/
-- copy: src=summary.rsync dest=/etc/arteria/misc/
+- copy: src=hiseq.rsync dest=/etc/arteria/misc/ owner={{ arteria_user }}
+- copy: src=ngi.rsync dest=/etc/arteria/misc/ owner={{ arteria_user }}
+- copy: src=summary.rsync dest=/etc/arteria/misc/ owner={{ arteria_user }}

--- a/ansible-st2-local/roles/bcl2fastq/tasks/install.yml
+++ b/ansible-st2-local/roles/bcl2fastq/tasks/install.yml
@@ -36,3 +36,5 @@
       executable: "{{ arteria_bcl2fastq_env_root }}/bin/pip"
       extra_args: "-U"
 
+- name: change file owner of arteria-bcl2fastq
+  shell: chown -R {{ arteria_user }} {{ arteria_bcl2fastq_env_root }}

--- a/ansible-st2-local/roles/bcl2fastq/tasks/main.yml
+++ b/ansible-st2-local/roles/bcl2fastq/tasks/main.yml
@@ -13,21 +13,25 @@
   file:
     state: directory
     path: "{{ arteria_bcl2fastq_config_root}}"
+    owner: "{{ arteria_user }}"
 
 - name: place arteria-bcl2fastq config file in "{{ arteria_bcl2fastq_app_config }}"
   template:
     src: bcl2fastq_app.config.j2
     dest: "{{ arteria_bcl2fastq_app_config }}"
+    owner: "{{ arteria_user }}"
 
 - name: place arteria-bcl2fastq config file in "{{ arteria_bcl2fastq_logger_config }}"
   template:
     src: bcl2fastq_logger.config.j2
     dest: "{{ arteria_bcl2fastq_logger_config }}"
+    owner: "{{ arteria_user }}"
 
 - name: deploy arteria-bcl2fastq supervisord config
   template:
     src: supervisor_arteria_bcl2fastq.conf.j2
     dest: /etc/supervisor/conf.d/bcl2fastq.conf
+    owner: "{{ arteria_user }}"
 
 - supervisorctl:
     name: "bcl2fastq-ws:"

--- a/ansible-st2-local/roles/runfolder/tasks/install.yml
+++ b/ansible-st2-local/roles/runfolder/tasks/install.yml
@@ -36,3 +36,6 @@
       executable: "{{ arteria_runfolder_env_root }}/bin/pip"
       extra_args: "-U"
 
+- name: change file owner of arteria-runfolder
+  shell: chown -R {{ arteria_user }} {{ arteria_runfolder_env_root }}
+

--- a/ansible-st2-local/roles/runfolder/tasks/install_config.yml
+++ b/ansible-st2-local/roles/runfolder/tasks/install_config.yml
@@ -4,16 +4,19 @@
   file:
     state: directory
     path: "{{ arteria_runfolder_config_root }}"
+    owner: "{{ arteria_user }}"
 
 - name: deploy arteria-runfolder app config
   template:
     src: runfolder_app.config.j2
     dest: "{{ arteria_runfolder_app_config }}"
+    owner: "{{ arteria_user }}"
 
 - name: deploy arteria-runfolder logger config
   template:
     src: runfolder_logger.config.j2
     dest: "{{ arteria_runfolder_logger_config }}"
+    owner: "{{ arteria_user }}"
 
 - name: deploy arteria-runfolder supervisord config
   template:

--- a/ansible-st2-local/roles/siswrap/tasks/install.yml
+++ b/ansible-st2-local/roles/siswrap/tasks/install.yml
@@ -36,3 +36,6 @@
       executable: "{{ arteria_siswrap_env_root }}/bin/pip"
       extra_args: "-U"
 
+- name: change file owner of arteria-siswrap
+  shell: chown -R {{ arteria_user }} {{ arteria_siswrap_env_root }}
+

--- a/ansible-st2-local/roles/siswrap/tasks/main.yml
+++ b/ansible-st2-local/roles/siswrap/tasks/main.yml
@@ -1,7 +1,5 @@
 ---
 
-# TODO Ensure all this is versioned!
-
 # This all assumes that the sisyphus role has been run before this.
 - include: install.yml
 
@@ -9,16 +7,19 @@
   file:
     state: directory
     path: "{{ arteria_siswrap_config_root }}"
+    owner: "{{ arteria_user }}"
 
 - name: deploying arteria-siswrap app config
   template:
     src: siswrap_app.config.j2
     dest: "{{ arteria_siswrap_app_config }}"
+    owner: "{{ arteria_user }}"
 
 - name: deploying arteria-siswrap logger config
   template:
     src: siswrap_logger.config.j2
     dest: "{{ arteria_siswrap_logger_config }}"
+    owner: "{{ arteria_user }}"
   notify:
      - restart siswrap
 

--- a/ansible-st2-local/roles/sisyphus/tasks/main.yml
+++ b/ansible-st2-local/roles/sisyphus/tasks/main.yml
@@ -43,7 +43,7 @@
   cpanm: name=File::NFSLock
 
 - name: create sisyphus code folder
-  file: path={{ sisyphus_path }} state=directory
+  file: path={{ sisyphus_path }} state=directory owner={{ arteria_sisyphus_user }}
 
 - name: get sisyphus code
   git: repo={{ sisyphus_git_repo }} version={{ sisyphus_repo_branch }} dest={{ sisyphus_path }}/sisyphus-tmp update=yes
@@ -63,8 +63,8 @@
 - name: remove sisyphus-tmp
   file: path={{ sisyphus_path }}/sisyphus-tmp state=absent
 
-- name: ensure latest version is globally readable
-  file: state=directory path={{ sisyphus_path }}/sisyphus-{{ sisyphus_version.stdout }} mode=775 recurse=yes
+- name: ensure latest version is globally readable and owned by proper user 
+  file: state=directory path={{ sisyphus_path }}/sisyphus-{{ sisyphus_version.stdout }} mode=775 recurse=yes owner={{ arteria_sisyphus_user }}
 
 - name: setup link to sisyphus latest
   file: state=link src={{ sisyphus_path }}/sisyphus-{{ sisyphus_version.stdout }} dest={{ sisyphus_path }}/sisyphus-latest mode=775


### PR DESCRIPTION
Biotank similar systems have more restrictive umasks than default configured hosts (for root user). Therefore all our deployment of custom software on these hosts fail, as the files will only be accessible by root. 

To prevent this we deploy all Arteria files as user arteria instead, and temporarily change root's umask when installing Python. 
