### PR TITLE
Create arteria user before using

### DIFF
--- a/ansible-st2-local/roles/arteria_node/meta/main.yml
+++ b/ansible-st2-local/roles/arteria_node/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - { role: arteria_common, tags: ['arteria_common'] }
+


### PR DESCRIPTION
Typical problem encountered when previously only tested on a non-clean system (where in this case the user had been created earlier from previous runs). 
