### PR TITLE
Use latest releases of products bcl2fastq, runfolder and siswrap.

### DIFF
--- a/ansible-st2-local/roles/bcl2fastq/defaults/main.yml
+++ b/ansible-st2-local/roles/bcl2fastq/defaults/main.yml
@@ -17,4 +17,4 @@ arteria_bcl2fastq_run_tests: False
 # fetch from a repo mounted at /arteria
 arteria_bcl2fastq_sources: git
 arteria_bcl2fastq_repo: https://github.com/arteria-project/arteria-bcl2fastq.git
-arteria_bcl2fastq_version: v1.1.0
+arteria_bcl2fastq_version: v1.1.1

--- a/ansible-st2-local/roles/runfolder/defaults/main.yml
+++ b/ansible-st2-local/roles/runfolder/defaults/main.yml
@@ -10,4 +10,4 @@ runfolder_path: /data/{{ ansible_hostname }}/runfolders
 # fetch from a repo mounted at /arteria
 arteria_runfolder_sources: git
 arteria_runfolder_repo: https://github.com/arteria-project/arteria-runfolder.git
-arteria_runfolder_version: v1.0.0
+arteria_runfolder_version: v1.0.1

--- a/ansible-st2-local/roles/siswrap/defaults/main.yml
+++ b/ansible-st2-local/roles/siswrap/defaults/main.yml
@@ -13,4 +13,4 @@ arteria_siswrap_run_tests: False
 # fetch from a repo mounted at /arteria
 arteria_siswrap_sources: git
 arteria_siswrap_repo: https://github.com/arteria-project/arteria-siswrap.git
-arteria_siswrap_version: v1.0.1
+arteria_siswrap_version: v1.0.2


### PR DESCRIPTION
Includes a new exception class in core, support for fetching bcl2fastq logs and returning better messages when errors occurs in a siswrap subprocess.
