### PR TITLE
Demultiplexing -> Unaligned

### DIFF
--- a/ansible-st2-local/roles/arteria_node/files/ngi.rsync
+++ b/ansible-st2-local/roles/arteria_node/files/ngi.rsync
@@ -15,7 +15,7 @@
 
 # Include full tree of some subdirs
 # This works if rsync is called with src dest, but not src/ dest
-+ /*/Demultiplexing/***
++ /*/Unaligned/***
 + /*/InterOp/***
 + /*/Sisyphus/***
 


### PR DESCRIPTION
Sisyphus renamed `Unaligned` to `Demultiplexing` for the `ngi_pipeline`, but this is not necessary, so now we don't. Therefore we also need to update the include pattern here.
